### PR TITLE
Fix import issue with cv2.aruco

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-pip install --upgrade -r requirements.txt
-wget -P source/yolo-coco/ https://pjreddie.com/media/files/yolov3.weights
+pip install --upgrade -r requirements.txt;
+pip uninstall opencv-contrib-python;
+pip install opencv-contrib-python;
+wget -P source/yolo-coco/ https://pjreddie.com/media/files/yolov3.weights;


### PR DESCRIPTION
There seems to be a bug where the opencv-contrib-python module needs to be uninstalled and then reinstalled for the aruco code to be imported correcty